### PR TITLE
Replace legacy API endpoint

### DIFF
--- a/almanach/adapters/api_route_v1.py
+++ b/almanach/adapters/api_route_v1.py
@@ -246,13 +246,13 @@ def list_entity(project_id):
     return controller.list_entities(project_id, start, end)
 
 
-# Temporary for AgileV1 migration
-@api.route("/instance/<instance_id>/create_date/<create_date>", methods=["PUT"])
+@api.route("/entity/instance/<instance_id>", methods=["PUT"])
 @authenticated
 @to_json
-def update_instance_create_date(instance_id, create_date):
-    logging.info("Update create date for instance %s to %s", instance_id, create_date)
-    return controller.update_instance_create_date(instance_id, create_date)
+def update_instance_entity(instance_id):
+    data = json.loads(request.data)
+    logging.info("Updating instance entity with id %s with data %s", instance_id, data)
+    return controller.update_active_instance_entity(instance_id=instance_id, **data)
 
 
 @api.route("/volume_types", methods=["GET"])

--- a/almanach/core/controller.py
+++ b/almanach/core/controller.py
@@ -15,7 +15,6 @@
 import logging
 import pytz
 
-from datetime import datetime
 from datetime import timedelta
 from dateutil import parser as date_parser
 from pkg_resources import get_distribution
@@ -103,15 +102,16 @@ class Controller(object):
             instance.last_event = rebuild_date
             self.database_adapter.insert_entity(instance)
 
-    def update_instance_create_date(self, instance_id, create_date):
-        logging.info("instance %s create date updated for %s" % (instance_id, create_date))
+    def update_active_instance_entity(self, instance_id, start_date):
         try:
             instance = self.database_adapter.get_active_entity(instance_id)
-            instance.start = datetime.strptime(create_date[0:19], "%Y-%m-%d %H:%M:%S")
+            instance.start = self._validate_and_parse_date(start_date)
+
+            logging.info("Updating entity for instance '{0}' with a new start_date={1}".format(instance_id, start_date))
             self.database_adapter.update_active_entity(instance)
-            return True
+            return instance
         except KeyError as e:
-            logging.error("Trying to update an instance with id '%s' not in the database yet." % instance_id)
+            logging.error("Instance '{0}' is not in the database yet.".format(instance_id))
             raise e
 
     def create_volume(self, volume_id, project_id, start, volume_type, size, volume_name, attached_to=None):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -72,20 +72,29 @@ class ApiTest(TestCase):
         assert_that(result[0], has_key('entity_id'))
         assert_that(result[0]['entity_id'], equal_to('123'))
 
-    def test_update_create_date_instance(self):
+    def test_update_instance_entity_with_a_new_start_date(self):
+        data = {
+            "start_date": "2014-01-01 00:00:00.0000",
+        }
+
         self.having_config('api_auth_token', 'some token value')
 
-        self.controller.should_receive('update_instance_create_date')\
-            .with_args("INSTANCE_ID", "2014-01-01 00:00:00.0000")\
-            .and_return(True)
+        self.controller.should_receive('update_active_instance_entity')\
+            .with_args(
+                instance_id="INSTANCE_ID",
+                start_date=data["start_date"],
+            ).and_return(a(instance().with_id('INSTANCE_ID')))
 
         code, result = self.api_update(
-            '/instance/INSTANCE_ID/create_date/2014-01-01 00:00:00.0000',
-            headers={'X-Auth-Token': 'some token value'}
+            '/entity/instance/INSTANCE_ID',
+            headers={'X-Auth-Token': 'some token value'},
+            data=data,
         )
 
         assert_that(code, equal_to(200))
-        assert_that(result, equal_to(True))
+        assert_that(result, has_key('entity_id'))
+        assert_that(result, has_key('start'))
+        assert_that(result, has_key('end'))
 
     def test_instances_with_wrong_authentication(self):
         self.having_config('api_auth_token', 'some token value')

--- a/tests/core/test_controller.py
+++ b/tests/core/test_controller.py
@@ -91,10 +91,10 @@ class ControllerTest(unittest.TestCase):
 
         self.controller.resize_instance(fake_instance.entity_id, "newly_flavor", dates_str)
 
-    def test_instance_create_date_updated(self):
+    def test_update_active_instance_entity_with_a_new_start_date(self):
         fake_instance1 = a(instance())
         fake_instance2 = fake_instance1
-        fake_instance2.start = "2015-10-05 12:04:00.0000Z"
+        fake_instance2.start = "2015-10-21T16:25:00.000000Z"
 
         (flexmock(self.database_adapter)
          .should_receive("get_active_entity")
@@ -107,7 +107,10 @@ class ControllerTest(unittest.TestCase):
          .with_args(fake_instance2)
          .once())
 
-        self.controller.update_instance_create_date(fake_instance1.entity_id, "2015-10-05 12:04:00.0000Z")
+        self.controller.update_active_instance_entity(
+            instance_id=fake_instance1.entity_id,
+            start_date="2015-10-21T16:25:00.000000Z",
+        )
 
     def test_instance_created_but_its_an_old_event(self):
         fake_instance = a(instance()


### PR DESCRIPTION
- Remove temporary API endpoint `/instance/<instance_id>/create_date/<create_date>`.
- Added a more generic endpoint `/entity/instance/<instance_id>` instead. This API call can be easily extended to other instance properties. At the moment, only the entity start date is handled.
