### PR TITLE
Do not use Gunicorn inside the app (override command line arguments)

### DIFF
--- a/almanach/api.py
+++ b/almanach/api.py
@@ -13,25 +13,18 @@
 # limitations under the License.
 
 from flask import Flask
-from gunicorn.app.base import Application
 
 from almanach.adapters import api_route_v1 as api_route
 from almanach.adapters.database_adapter import DatabaseAdapter
 from almanach.core.controller import Controller
 
 
-class AlmanachApi(Application):
+class AlmanachApi(object):
 
-    def __init__(self):
-        super(AlmanachApi, self).__init__()
-
-    def init(self, parser, opts, args):
-        self._controller = Controller(DatabaseAdapter())
-
-    def load(self):
-        api_route.controller = self._controller
+    def run(self):
+        api_route.controller = Controller(DatabaseAdapter())
 
         app = Flask("almanach")
         app.register_blueprint(api_route.api)
 
-        return app
+        return app.run(port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Flask==0.10.1
 PyYAML==3.11
-gunicorn==19.1.0
 jsonpickle==0.7.1
 pymongo==2.7.2
 kombu>=3.0.30


### PR DESCRIPTION
Gunicorn override the application command line arguments and that create an issue with v1.0.5.

We don't need to force people to use Gunicorn as WSGI wrapper.
