### PR TITLE
Do not ignore silently instance.delete.end events when the entity is not created

### DIFF
--- a/almanach/adapters/database_adapter.py
+++ b/almanach/adapters/database_adapter.py
@@ -79,6 +79,10 @@ class DatabaseAdapter(object):
         return self.db.entity.find({"entity_id": entity_id}).count()
 
     @database
+    def has_active_entity(self, entity_id):
+        return self.db.entity.find({"entity_id": entity_id, "end": None}).count() == 1
+
+    @database
     def list_entities(self, project_id, start, end, entity_type=None):
         args = {"project_id": project_id, "start": {"$lte": end}, "$or": [{"end": None}, {"end": {"$gte": start}}]}
         if entity_type:

--- a/almanach/common/almanach_entity_not_found_exception.py
+++ b/almanach/common/almanach_entity_not_found_exception.py
@@ -1,0 +1,2 @@
+class AlmanachEntityNotFoundException(Exception):
+    pass

--- a/almanach/core/controller.py
+++ b/almanach/core/controller.py
@@ -19,6 +19,7 @@ from datetime import timedelta
 from dateutil import parser as date_parser
 from pkg_resources import get_distribution
 
+from almanach.common.almanach_entity_not_found_exception import AlmanachEntityNotFoundException
 from almanach.common.date_format_exception import DateFormatException
 from almanach.core.model import Instance, Volume, VolumeType
 from almanach import config
@@ -66,6 +67,9 @@ class Controller(object):
         self.database_adapter.insert_entity(entity)
 
     def delete_instance(self, instance_id, delete_date):
+        if not self.database_adapter.has_active_entity(instance_id):
+            raise AlmanachEntityNotFoundException("InstanceId: {0} Not Found".format(instance_id))
+
         delete_date = self._validate_and_parse_date(delete_date)
         logging.info("instance %s deleted on %s" % (instance_id, delete_date))
         self.database_adapter.close_active_entity(instance_id, delete_date)

--- a/tests/adapters/test_database_adapter.py
+++ b/tests/adapters/test_database_adapter.py
@@ -49,6 +49,14 @@ class DatabaseAdapterTest(unittest.TestCase):
         self.assertEqual(self.db.entity.count(), 1)
         self.assert_mongo_collection_contains("entity", fake_instance)
 
+    def test_has_active_entity_not_found(self):
+        self.assertFalse(self.adapter.has_active_entity("my_entity_id"))
+
+    def test_has_active_entity_found(self):
+        fake_instance = a(instance().with_id("my_entity_id"))
+        self.adapter.insert_entity(fake_instance)
+        self.assertTrue(self.adapter.has_active_entity("my_entity_id"))
+
     def test_get_instance_entity(self):
         fake_entity = a(instance().with_metadata({}))
 


### PR DESCRIPTION
- When events are received in the wrong order, instance delete are not taken into consideration
- There is already a mechanism that send messages to the retry queue
- This fix check the existence of the entity before doing the database update
- This fix send to the retry queue messages with entity not found so they can be reprocessed later
